### PR TITLE
chore(deps): bump .NET SDK to 10.0.103 and update NuGet packages

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
     "rollForward": "latestFeature",
-    "version": "10.0.102"
+    "version": "10.0.103"
   }
 }

--- a/src/DPI/DPI.csproj
+++ b/src/DPI/DPI.csproj
@@ -11,14 +11,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Devlead.Console" Version="2026.1.14.558" />
+    <PackageReference Include="Devlead.Console" Version="2026.2.11.575" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
     <PackageReference Include="Cake.Core" Version="6.0.0" />
     <PackageReference Include="Cake.Common" Version="6.0.0" />
-    <PackageReference Include="Cake.Bridge.DependencyInjection" Version="2026.1.14.460" />
+    <PackageReference Include="Cake.Bridge.DependencyInjection" Version="2026.2.11.478" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1 " Condition="'$(TargetFramework)' == 'net8.0'" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.12" Condition="'$(TargetFramework)' == 'net9.0'" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" Condition="'$(TargetFramework)' == 'net10.0'" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.13" Condition="'$(TargetFramework)' == 'net9.0'" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.3" Condition="'$(TargetFramework)' == 'net10.0'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- global.json: SDK 10.0.102 → 10.0.103
- Devlead.Console: 2026.1.14.558 → 2026.2.11.575
- Cake.Bridge.DependencyInjection: 2026.1.14.460 → 2026.2.11.478
- Microsoft.Extensions.Http: 9.0.12 → 9.0.13 (net9.0), 10.0.2 → 10.0.3 (net10.0)